### PR TITLE
fix definition of extrinsics in CustomNuScensDataset

### DIFF
--- a/projects/mmdet3d_plugin/datasets/nuscenes_dataset.py
+++ b/projects/mmdet3d_plugin/datasets/nuscenes_dataset.py
@@ -64,7 +64,7 @@ class CustomNuScenesDataset(NuScenesDataset):
                 viewpad[:intrinsic.shape[0], :intrinsic.shape[1]] = intrinsic
                 lidar2img_rt = (viewpad @ lidar2cam_rt.T)
                 intrinsics.append(viewpad)
-                extrinsics.append(lidar2cam_rt)
+                extrinsics.append(np.linalg.inv(lidar2cam_rt.T))
                 lidar2img_rts.append(lidar2img_rt)
 
             input_dict.update(


### PR DESCRIPTION
Previously, the `extrinsics` in `CustomNuScenesDataset` stored the transformation from **lidar to camera**. To follow the convention of **camera to lidar**, an inverse is applied. An example of extrinsics of 6 cameras after the modification is:

```
# CAM_FRONT
>>> extrinsics[0].round(2)
array([[ 1.  ,  0.01, -0.  , -0.01],
       [ 0.  ,  0.02,  1.  ,  0.53],
       [ 0.01, -1.  ,  0.02, -0.32],
       [ 0.  ,  0.  ,  0.  ,  1.  ]])
# CAM_FRONT_RIGHT
>>> extrinsics[1].round(2)
array([[ 0.55, -0.01,  0.83,  0.5 ],
       [-0.83,  0.02,  0.55,  0.43],
       [-0.03, -1.  ,  0.  , -0.33],
       [ 0.  ,  0.  ,  0.  ,  1.  ]])
# CAM_FRONT_LEFT
>>> extrinsics[2].round(2)
array([[ 0.57,  0.  , -0.82, -0.49],
       [ 0.82,  0.02,  0.57,  0.3 ],
       [ 0.02, -1.  ,  0.01, -0.33],
       [ 0.  ,  0.  ,  0.  ,  1.  ]])
# CAM_BACK
>>> extrinsics[3].round(2)
array([[-1.  ,  0.01, -0.  , -0.  ],
       [ 0.  ,  0.01, -1.  , -0.98],
       [-0.01, -1.  , -0.01, -0.29],
       [ 0.  ,  0.  ,  0.  ,  1.  ]])
# CAM_BACK_LEFT
>>> extrinsics[4].round(2)
array([[-0.32,  0.02, -0.95, -0.48],
       [ 0.95,  0.03, -0.32,  0.09],
       [ 0.02, -1.  , -0.03, -0.25],
       [ 0.  ,  0.  ,  0.  ,  1.  ]])
# CAM_BACK_RIGHT
>>> extrinsics[5].round(2)
array([[-0.36, -0.01,  0.93,  0.48],
       [-0.93,  0.04, -0.36, -0.06],
       [-0.04, -1.  , -0.02, -0.28],
       [ 0.  ,  0.  ,  0.  ,  1.  ]])
```
where the lidar coordinate system is `x-right`, `y-forward`, `z-upward` following [NuScenes guide](https://www.nuscenes.org/nuscenes#data-collection).