### PR TITLE
fix size mismatch error

### DIFF
--- a/projects/mmdet3d_plugin/models/dense_heads/petrv2_dnhead.py
+++ b/projects/mmdet3d_plugin/models/dense_heads/petrv2_dnhead.py
@@ -595,7 +595,7 @@ class PETRv2DNHead(AnchorFreeHead):
             tmp[..., 4:5] = tmp[..., 4:5].sigmoid()
 
             if self.with_time:
-                tmp[..., 8:] = tmp[..., 8:] / mean_time_stamp
+                tmp[..., 8:] = tmp[..., 8:] / mean_time_stamp[:, None, None]
 
             outputs_coord = tmp
             outputs_classes.append(outputs_class)


### PR DESCRIPTION
Thanks for your wonderful work! I meet a runtime error "RuntimeError: The size of tensor a (2) must match the size of tensor b (4) at non-singleton dimension 2" when running the petrv2 dn setting. I fix it now.